### PR TITLE
Added the ability to skip joins for sub-queries

### DIFF
--- a/SanteDB.OrmLite.Test/Model/Entities/DbEntity.cs
+++ b/SanteDB.OrmLite.Test/Model/Entities/DbEntity.cs
@@ -29,7 +29,7 @@ namespace SanteDB.Persistence.Data.ADO.Data.Model.Entities
     /// <summary>
     /// Represents an entity in the database
     /// </summary>
-    [Table("ent_tbl")]
+    [Table("ent_tbl"), SkipHint("template"), SkipHint("classConcept"), SkipHint("determinerConcept")]
 	public class DbEntity : DbIdentified
 	{
         /// <summary>

--- a/SanteDB.OrmLite.Test/SanteDB.OrmLite.Test.csproj
+++ b/SanteDB.OrmLite.Test/SanteDB.OrmLite.Test.csproj
@@ -133,7 +133,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="SanteDB.Core.Model" Version="2.1.0.0" />
+        <PackageReference Include="SanteDB.Core.Model" Version="2.1.1.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/SanteDB.OrmLite/Attributes/SkipHintAttribute.cs
+++ b/SanteDB.OrmLite/Attributes/SkipHintAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SanteDB.OrmLite.Attributes
+{
+    /// <summary>
+    /// The skip hint attribute allows the more complex auto-joining 
+    /// tools to understand when skipping a join can be performed
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class SkipHintAttribute : Attribute
+    {
+
+        /// <summary>
+        /// Skip attribute
+        /// </summary>
+        public SkipHintAttribute(string queryHint)
+        {
+            this.QueryHint = queryHint;
+        }
+
+        /// <summary>
+        /// Gets the query path which , if not present in the query, indicates the class can be skipped
+        /// </summary>
+        public String QueryHint { get; }
+    }
+}

--- a/SanteDB.OrmLite/SanteDB.OrmLite.csproj
+++ b/SanteDB.OrmLite/SanteDB.OrmLite.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <PackageId>SanteDB.OrmLite</PackageId>
     <Title>SanteDB.OrmLite</Title>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Description>SanteDB Lightweight ORM Mapper</Description>
     <Authors>SanteSuite Contributors</Authors>
     <PackageTags>SanteDB</PackageTags>
@@ -66,7 +66,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="SanteDB.Core.Model" Version="2.1.0.0" />
+        <PackageReference Include="SanteDB.Core.Model" Version="2.1.1.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -143,8 +143,8 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="SanteDB.Core.Api" Version="2.1.0.0" />
-        <PackageReference Include="SanteDB.BI" Version="2.1.0.0" />
+        <PackageReference Include="SanteDB.Core.Api" Version="2.1.1.0" />
+        <PackageReference Include="SanteDB.BI" Version="2.1.1.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/SanteDB.OrmLite/TableMapping.cs
+++ b/SanteDB.OrmLite/TableMapping.cs
@@ -65,7 +65,7 @@ namespace SanteDB.OrmLite
         {
             get
             {
-                if(this.m_primaryKey == null)
+                if (this.m_primaryKey == null)
                     this.m_primaryKey = this.Columns.Where(o => o.IsPrimaryKey);
                 return this.m_primaryKey;
             }
@@ -103,6 +103,20 @@ namespace SanteDB.OrmLite
         }
 
         /// <summary>
+        /// Creates a table mapping that is redirected
+        /// </summary>
+        public static TableMapping Redirect(Type original, Type shadow)
+        {
+            var retVal = new TableMapping(original);
+            var shadowMap = Get(shadow);
+            var invalidMaps = retVal.m_mappings.Where(c => !shadowMap.Columns.Any(s => s.Name == c.Value.Name));
+            foreach (var i in invalidMaps.ToArray())
+                retVal.m_mappings.Remove(i.Key);
+            retVal.TableName = shadowMap.TableName;
+            return retVal;
+        }
+
+        /// <summary>
         /// Get column mapping
         /// </summary>
         public ColumnMapping GetColumn(PropertyInfo pi)
@@ -128,7 +142,7 @@ namespace SanteDB.OrmLite
         public ColumnMapping GetColumn(string propertyName, bool scanHeirarchy = false)
         {
             ColumnMapping map = null;
-            if(!this.m_mappings.TryGetValue(propertyName, out map) && scanHeirarchy &&
+            if (!this.m_mappings.TryGetValue(propertyName, out map) && scanHeirarchy &&
                 this.OrmType.BaseType != typeof(Object))
             {
                 var t = TableMapping.Get(this.OrmType.BaseType);
@@ -149,4 +163,5 @@ namespace SanteDB.OrmLite
                 return TableMapping.Get(att.AssociationTable);
         }
     }
+
 }


### PR DESCRIPTION
Sometimes when performing sub-queries, the ORM would append unnecessary joins which would slow down the queries. This code detects that condition and allows classes in the ORM to provide hints when joins are not necessary.

```
/// When determining whether to join, this attribute hints that it can be skipped unless classConcept is a query filter
[SkipHint("classConcept")]
public class DbEntity {
```